### PR TITLE
Cleaner side_effect lambdas

### DIFF
--- a/examples/strings/tests/test_strings.py
+++ b/examples/strings/tests/test_strings.py
@@ -1,6 +1,6 @@
 from examples.strings import strings
 import io
-from sundew.test import test, arg, patched
+from sundew.test import test
 
 test(strings.concatenate)(
     input={"a": "123", "b": "456"},
@@ -18,15 +18,15 @@ test(strings.print_string)(
     input={"a": "123"},
     patches={"sys.stdout": io.StringIO()},
     side_effects=[
-        lambda: patched["sys.stdout"].getvalue() == "123\n",
-        lambda: arg["a"] == "123",
+        lambda _: _.patches["sys.stdout"].getvalue() == "123\n",
+        lambda _: _.a == "123",
     ],
 )(
     input={"a": "456"},
     patches={"sys.stdout": io.StringIO()},
     side_effects=[
-        lambda: patched["sys.stdout"].getvalue() == "456\n",
-        lambda: arg["a"] == "456",
+        lambda _: _.patches["sys.stdout"].getvalue() == "456\n",
+        lambda _: _.a == "456",
     ],
 )
 
@@ -35,6 +35,6 @@ test(strings.print_string)(
 #     input={"a": "789"},
 #     patches={"sys.stdout": io.StringIO()},
 #     side_effects=[
-#         lambda: patched["sys.stdout"].getvalue() == "7ate9\n",
+#         lambda _: _.patched["sys.stdout"].getvalue() == "7ate9\n",
 #     ],
 # )

--- a/sundew/side_effects.py
+++ b/sundew/side_effects.py
@@ -1,6 +1,6 @@
 import ast
 import inspect
-from typing import Callable
+from typing import Any, Callable
 
 
 # Generate assert statement from a Compare node
@@ -53,7 +53,7 @@ class SideEffectGetter(ast.NodeTransformer):
         return self.lambda_sources
 
 
-def get_source(funcs: list[Callable[[], None]]) -> set[str]:
+def get_source(funcs: list[Callable[[Any], bool]]) -> set[str]:
     side_effects = SideEffectGetter()
     for func in funcs:
         code_string = inspect.getsource(func).strip()

--- a/sundew/types.py
+++ b/sundew/types.py
@@ -8,4 +8,4 @@ class FunctionTest(BaseModel):
     input: dict[str, Any] = dict()
     returns: Any | None = None
     patches: dict[str, Any] = dict()
-    side_effects: list[Callable[[], None]] = []
+    side_effects: list[Callable[[Any], bool]] = []

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,18 +1,18 @@
 from sundew.graph import Graph
-from sundew.test import test, arg
+from sundew.test import test
 import tests.fixtures as fixtures
 
 test(Graph.add_connections)(
     input={"self": Graph(), "connections": [("A", "B")]},
     side_effects=[
-        lambda: arg["self"].dep_graph["A"] == {"B"},
+        lambda _: _.self.dep_graph["A"] == {"B"},
     ],
 )
 
 test(Graph.add)(
     input={"self": Graph(), "node1": "A", "node2": "B"},
     side_effects=[
-        lambda: arg["self"].dep_graph["A"] == {"B"},
+        lambda _: _.self.dep_graph["A"] == {"B"},
     ],
 )
 

--- a/tests/test_side_effects.py
+++ b/tests/test_side_effects.py
@@ -1,4 +1,4 @@
-from sundew.test import test, arg
+from sundew.test import test
 from sundew import side_effects
 import ast
 
@@ -13,31 +13,31 @@ test(side_effects.ConvertSideEffect.visit)(
 test(side_effects.SideEffectGetter.visit_Lambda)(
     input={
         "self": side_effects.SideEffectGetter(),
-        "node": ast.parse("lambda a: a.b == a.c"),
+        "node": ast.parse("lambda _: _.b == _.c").body[0].value,  # type: ignore
     },
-    side_effects=[lambda: arg["self"].lambda_sources == {"lambda a: a.b == a.c"}],
+    side_effects=[lambda _: _.self.lambda_sources == {"lambda _: _.b == _.c"}],
 )
 
 test(side_effects.SideEffectGetter.get)(
     input={
         "self": side_effects.SideEffectGetter(),
-        "code_string": "lambda a: a.b == a.c",
+        "code_string": "lambda _: _.b == _.c",
     },
-    returns={"lambda a: a.b == a.c"},
+    returns={"lambda _: _.b == _.c"},
 )
 
 test(side_effects.get_source)(
-    input={"funcs": [lambda: arg["a"] == arg["b"]]},
-    returns={"lambda: arg['a'] == arg['b']"},
+    input={"funcs": [lambda _: _.a == _.b]},
+    returns={"lambda _: _.a == _.b"},
 )(
     input={
         "funcs": [
-            lambda: arg["a"] == arg["b"],
-            lambda: (arg["c"] - arg["d"]) != arg["e"],
+            lambda _: _.a == _.b,
+            lambda _: (_.c - _.d) != _.e,
         ]
     },
-    returns={"lambda: arg['a'] == arg['b']", "lambda: arg['c'] - arg['d'] != arg['e']"},
+    returns={"lambda _: _.a == _.b", "lambda _: _.c - _.d != _.e"},
 )(
-    input={"funcs": [lambda: arg["a"] == arg["b"], lambda: arg["a"] == arg["b"]]},
-    returns={"lambda: arg['a'] == arg['b']"},
+    input={"funcs": [lambda _: _.a == _.b, lambda _: _.a == _.b]},
+    returns={"lambda _: _.a == _.b"},
 )


### PR DESCRIPTION
Functionality remain the same, but now supporting a `_` argument, instead of globals provided by sundew. Should be both shorter and cleaner. 

Would love a world where the dynamic types worked in IDEs while writing the side_effects, but I'm not sure it's possible....