### PR TITLE
Allow test selection by function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A new kind of testing framework for Python.
 
 > **Warning**
-> This projct is barely even a proof-of-concept still and is not close to being ready for production use. This warning will be updated/removed when that has changed!
+> This project is barely even a proof-of-concept still and is not close to being ready for production use. This warning will be updated/removed when that has changed!
   
 ## To-do
 
@@ -15,23 +15,23 @@ Major things that still need to be done before making public (in rough order):
 - [x] Simplify writing multiple tests for a function
 - [x] Look into a better side_effect signature
 - [x] Fixtures (Basics implemented)
-- [ ] Write tests for sundew 🤭 (Almost there...)
-- [ ] Figure out test naming
-- [ ] Basic test selection support
+- [x] Write initial tests for sundew
+- [ ] ~Figure out test naming~ (Decided for now, this isn't necessary)
+- [x] Basic test selection support (Can select tests by function name with --function option)
 - [x] Asyncio support/examples (basic implementation)
-- [ ] Documentation
 - [ ] Implement smart test runner
 - [ ] Implement automatic sub-function test cases
 - [ ] Implement untested sub-function detection
 - [ ] Parallel test runner support
+- [ ] Documentation
 - [ ] Add code of conduct
 - [ ] Add contribution guidelines
 - [x] Setup Github Actions to run CI on PR
 - [x] Setup Github Actions to release new versions to PyPi
+- [ ] Mutation testing/coverage reporting
 - [ ] Release version 0.1.0 to PyPi
 
 Future items to look into:
 
-- [ ] Mutation testing
 - [ ] Hypothesis integration?
 - [ ] Test-case generation for runtime exceptions?

--- a/sundew/__main__.py
+++ b/sundew/__main__.py
@@ -12,7 +12,13 @@ app = typer.Typer()
 
 
 @app.command()
-def run(module: str) -> None:
+def run(
+    module: str,
+    function: str = typer.Option(  # noqa: B008
+        "",
+        help="Run all tests for this function.",
+    ),
+) -> None:
     config.modules = {"module.name"}
 
     if os.path.isdir(module):
@@ -42,7 +48,7 @@ def run(module: str) -> None:
         else:
             ...
 
-    test.run()
+    test.run(function_name=function)
 
 
 if __name__ == "__main__":

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -21,14 +21,13 @@ test(Graph.dependencies)(
     returns={},
 )
 
-
 test(Graph.usage)(
     setup={fixtures.setup_empty_graph},
     kwargs={"self": Graph(), "node": "B"},
     returns={},
 )
 
-# Note: chained tests break failure links (always link to topmost test)
+# Note: chained tests break failure links (always link to top most test)
 test(Graph.usage)(
     kwargs={"self": fixtures.setup_empty_graph, "node": "B"},
     returns={"A"},


### PR DESCRIPTION
Can now select tests by the name of the function they are testing. New `--function` option allows this. Does not currently run the dependent functions, but I'm tackling the smart test runner soon so I may revisit that decision then