### PR TITLE
Add better support for all side_effect operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Major things that still need to be done before making public (in rough order):
 - [x] Cache auto regression tests so they have no performance impact
 - [x] Documentation
 - [x] Expand Python version compatibility (Now supports Python 3.9 -> 3.11)
+- [x] Handle more advanced test side-effects (<=, >=, in, etc)
 - [ ] Improve sundew test coverage
-- [ ] Handle more advanced test side-effects (<=, >=, in, etc)
 - [ ] Add "Here be dragons" disclaimers to docs
 - [ ] Upate README and move to do list into GH issues
 - [ ] Setup Github Actions to build and release new versions to PyPi

--- a/sundew/side_effects.py
+++ b/sundew/side_effects.py
@@ -4,17 +4,52 @@ from collections.abc import Callable
 from typing import Any
 
 
+def generate_inverse_operation_str(  # noqa: C901, PLR0911
+    operation: ast.cmpop,
+) -> str:
+    if isinstance(operation, ast.Eq):
+        return "!="
+    if isinstance(operation, ast.NotEq):
+        return "=="
+
+    if isinstance(operation, ast.Lt):
+        return ">="
+    if isinstance(operation, ast.GtE):
+        return "<"
+
+    if isinstance(operation, ast.LtE):
+        return ">"
+    if isinstance(operation, ast.Gt):
+        return "<="
+
+    if isinstance(operation, ast.Is):
+        return "is not"
+    if isinstance(operation, ast.IsNot):
+        return "is"
+
+    if isinstance(operation, ast.In):
+        return "is not in"
+    if isinstance(operation, ast.NotIn):
+        return "is in"
+    return "unknown operator"
+
+
 # Generate assert statement from a Compare node
 def generate_compare_assert(node: ast.Compare) -> ast.Assert:
     return ast.Assert(
         test=node,
         msg=ast.JoinedStr(
             values=[
-                ast.Constant(value="left="),
+                ast.Constant(
+                    value=f"Side-effect '{ast.unparse(node)}' failed because: "
+                ),
+                ast.Constant(value=f"{ast.unparse(node.left)} == "),
                 ast.FormattedValue(value=node.left, conversion=-1),
-                ast.Constant(value=" right="),
+                ast.Constant(value=", and "),
+                ast.FormattedValue(value=node.left, conversion=-1),
+                ast.Constant(value=f" {generate_inverse_operation_str(node.ops[0])} "),
                 ast.FormattedValue(value=node.comparators[0], conversion=-1),
-            ],
+            ]
         ),
     )
 

--- a/tests/examples/test_simple_example.py
+++ b/tests/examples/test_simple_example.py
@@ -19,3 +19,10 @@ test(simple_example.simple_sleep)(
     kwargs={"secs": 2},
     returns=None,
 )
+
+
+test(simple_example.quadratic)(
+    kwargs={"a": 1, "b": -8, "c": 5},
+    returns=(7.3166247903554, 0.6833752096446002),
+    side_effects=[lambda _: _.a < 5],  # noqa: PLR2004
+)

--- a/tests/test_side_effects.py
+++ b/tests/test_side_effects.py
@@ -8,7 +8,9 @@ test(side_effects.ConvertSideEffect.visit)(
         "self": side_effects.ConvertSideEffect(),
         "node": ast.parse("lambda a: a.b == a.c"),
     },
-    returns=ast.parse("assert a.b == a.c, f'left={a.b} right={a.c}'"),
+    returns=ast.parse(
+        """assert a.b == a.c, f"Side-effect 'a.b == a.c' failed because: a.b == {a.b}, and {a.b} != {a.c}" """  # noqa: E501
+    ),
 )
 
 test(side_effects.SideEffectGetter.visit_Lambda)(


### PR DESCRIPTION
Adds clearer failure messages for side_effects that use a single `==`, `!=`, `>=`, `<=`, `>`, `<`, `is`, `is not`, `in`, or `not in` operator