### PR TITLE
fix imports not being found

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -29,7 +29,7 @@ If you are excited about trying something brand new and are willing to except th
 Sundew is both a module for writing tests, and a CLI for running them. Once you're ready to get started you can easily install sundew by adding it to your pyproject.toml and/or by running:
 
 ```pip
-pip install -U sundew
+pip install --user sundew
 ```
 or
 ```poetry

--- a/docs/pages/writing-tests.md
+++ b/docs/pages/writing-tests.md
@@ -1,7 +1,12 @@
 # Writing Tests
 
 ## Directory Structure
-Tests are typically written in python files within a `tests` directory at the root of your project. You can have many files within that directory and can use sub-directories to organize those files to your liking. Sundew is not very opinionated about subdirectories, or how the test files are named so feel free to structure this directory how you'd like. 
+Tests _must_ be written in python files within a `tests` directory at the root of your project. You can have many files within that directory and can use sub-directories to organize those files to your liking. Sundew is not very opinionated about subdirectories, or how the test files are named so feel free to structure this directory how you'd like. 
+
+Your code may either be:
+- Structured as a module, adjacent to the `test` directory
+- Stored as a single script, adjacent to the `test` directory
+- Stored as a script in a common directory such as `src` (name does not matter), adjacent to the `test` directory (This is the least recommended approach as it breaks most IDE's ability to find your code when you import it, but sundew will still attempt to dsearch and find these imports when running tests)
 
 
 ## Imports

--- a/sundew/main.py
+++ b/sundew/main.py
@@ -1,3 +1,4 @@
+import glob
 import importlib
 import importlib.util
 import os
@@ -10,6 +11,15 @@ from sundew import test
 from sundew.config import config
 
 app = typer.Typer()
+
+import sys
+
+
+class DebugFinder:
+    @classmethod
+    def find_spec(cls, name, path, target=None):
+        print(f"Importing {name!r}")
+        return None
 
 
 @app.command()
@@ -29,6 +39,36 @@ def run(
     ),
 ) -> None:
     config.modules = {"module.name"}
+
+    class ModuleFinder:
+        @classmethod
+        def find_spec(cls, name, path, target=None):
+            module_path = module
+            # Back up until we get to the root of the project directory
+            while "tests" in str(module_path):
+                module_path = module_path.parent
+
+            # If we're testing a module
+            module_init = module_path / name / "__init__.py"
+            if module_init.exists():
+                # If there is an __init__.py
+                if spec := importlib.util.spec_from_file_location(name, module_init):
+                    return spec
+
+            # If we're testing a script, look around for it
+            if possible_import := glob.glob(
+                f"{module_path}/**/{name}*py", recursive=True
+            ):
+                # If there is an __init__.py
+                if spec := importlib.util.spec_from_file_location(
+                    name, Path(possible_import[0])
+                ):
+                    return spec
+
+            return None
+
+    # Import user's code from tests
+    sys.meta_path.append(ModuleFinder)
 
     if module.is_dir():
         for dirpath, _, fnames in os.walk(module):


### PR DESCRIPTION
Found a bug with the first release where sundew couldn't properly import the users' code into the test file unless used with `python -m sundew ./tests`. I believe this added logic adds what we need for `sundew ./tests` to work properly (and actually be more flexible to the location of the source code).